### PR TITLE
Set active tab when using named keys tabs

### DIFF
--- a/TabsX.php
+++ b/TabsX.php
@@ -15,7 +15,6 @@ use yii\helpers\ArrayHelper;
 use yii\bootstrap\Dropdown;
 use yii\bootstrap\Tabs;
 use yii\base\InvalidConfigException;
-use yii\web\View;
 use kartik\base\WidgetTrait;
 
 /**
@@ -205,13 +204,6 @@ class TabsX extends Tabs
      * @var string the crumb separator for the dropdown headers in the print view when `printHeaderCrumbs` is `true`
      */
     public $printCrumbSeparator = ' &raquo; ';
-    
-    /**
-     * @var integer the position where the client JS hash variables for the TabsX widget will be loaded. 
-     * Defaults to `View::POS_HEAD`. This can be set to `View::POS_READY` for specific scenarios like when
-     * rendering the widget via `renderAjax`.
-     */
-    public $hashVarLoadPosition = View::POS_HEAD;
 
     /**
      * @var string the hashed global variable name storing the pluginOptions
@@ -309,7 +301,8 @@ class TabsX extends Tabs
         $headers = $panes = $labels = [];
 
         if (!$this->hasActiveTab() && !empty($this->items)) {
-            $this->items[0]['active'] = true;
+        	reset($this->items);
+            $this->items[key($this->items)]['active'] = true;
         }
 
         foreach ($this->items as $n => $item) {


### PR DESCRIPTION
When using named keys for tab definition, setting the active tab should be done using the keyname of the first tab.

## Scope
This pull request includes a

- [X] Bug fix
- [ ] New feature
- [ ] Translation

## Changes
The following changes were made (this change is also documented in the [change log](https://github.com/kartik-v/yii2-tabs-x/blob/master/CHANGE.md)):

- Fix setting default active tab when using tab definition with keynames 